### PR TITLE
v0.2.0.0 - deprecate MaximumLineCountBeforeNextStage

### DIFF
--- a/YetAnotherPacketParser/YetAnotherPacketParser/HtmlPacketCompilerOptions.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/HtmlPacketCompilerOptions.cs
@@ -7,7 +7,6 @@ namespace YetAnotherPacketParser
         public HtmlPacketCompilerOptions()
         {
             this.StreamName = string.Empty;
-            this.MaximumLineCountBeforeNextStage = 1;
             this.MaximumPackets = 1000;
             this.MaximumPacketSizeInBytes = 1 * 1024 * 1024; // 1 MB
         }
@@ -16,6 +15,7 @@ namespace YetAnotherPacketParser
 
         public OutputFormat OutputFormat => OutputFormat.Html;
 
+        [Obsolete("No longer used")]
         public int MaximumLineCountBeforeNextStage { get; set; }
 
         public int MaximumPackets { get; set; }

--- a/YetAnotherPacketParser/YetAnotherPacketParser/IPacketConverterOptions.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/IPacketConverterOptions.cs
@@ -8,6 +8,7 @@ namespace YetAnotherPacketParser
 
         public OutputFormat OutputFormat { get; }
 
+        [Obsolete("No longer used")]
         public int MaximumLineCountBeforeNextStage { get; }
 
         public int MaximumPackets { get; }

--- a/YetAnotherPacketParser/YetAnotherPacketParser/JsonPacketCompilerOptions.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/JsonPacketCompilerOptions.cs
@@ -7,7 +7,6 @@ namespace YetAnotherPacketParser
         public JsonPacketCompilerOptions()
         {
             this.StreamName = string.Empty;
-            this.MaximumLineCountBeforeNextStage = 1;
             this.MaximumPackets = 1000;
             this.MaximumPacketSizeInBytes = 1 * 1024 * 1024; // 1 MB
             this.PrettyPrint = true;
@@ -17,6 +16,7 @@ namespace YetAnotherPacketParser
 
         public OutputFormat OutputFormat => OutputFormat.Json;
 
+        [Obsolete("No longer used")]
         public int MaximumLineCountBeforeNextStage { get; set; }
 
         public int MaximumPackets { get; set; }

--- a/YetAnotherPacketParser/YetAnotherPacketParser/PacketConverter.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/PacketConverter.cs
@@ -133,7 +133,6 @@ namespace YetAnotherPacketParser
 
             LinesParserOptions parserOptions = new LinesParserOptions()
             {
-                MaximumLineCountBeforeNextStage = options.MaximumLineCountBeforeNextStage
             };
             LinesParser parser = new LinesParser(parserOptions);
             IResult<PacketNode> packetNodeResult = parser.Parse(linesResult.Value);

--- a/YetAnotherPacketParser/YetAnotherPacketParser/Parser/LinesParserOptions.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Parser/LinesParserOptions.cs
@@ -10,12 +10,13 @@ namespace YetAnotherPacketParser.Parser
 
         public LinesParserOptions()
         {
-            this.MaximumLineCountBeforeNextStage = 1;
+            // this.MaximumLineCountBeforeNextStage = 1;
         }
 
         /// <summary>
         /// The number of extra lines to search for the next stage/token (like ANSWER or a bonus part value)
         /// </summary>
+        [Obsolete("This parameter is no longer used")]
         public int MaximumLineCountBeforeNextStage
         {
             get => this.maximumLineCountBeforeNextStage;

--- a/YetAnotherPacketParser/YetAnotherPacketParser/Strings.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Strings.cs
@@ -80,6 +80,11 @@ namespace YetAnotherPacketParser
             return $"Unable to open the .docx file: {message}";
         }
 
+        public static string UnexpectedToken(LineType expected, LineType actual)
+        {
+            return $@"Unexpected line found. Was expecting a line of type ""{expected}"", but found a line of type ""{actual}""";
+        }
+
         public static string UnknownError(string errorMessage)
         {
             return $"Unknown error: {errorMessage}";

--- a/YetAnotherPacketParser/YetAnotherPacketParser/YetAnotherPacketParser.csproj
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/YetAnotherPacketParser.csproj
@@ -24,8 +24,8 @@
 
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.11.3" />
-    <PackageReference Include="HtmlSanitizer" Version="5.0.343" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+    <PackageReference Include="HtmlSanitizer" Version="5.0.376" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/YetAnotherPacketParser/YetAnotherPacketParserAzureFunction/YetAnotherPacketParserParse.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParserAzureFunction/YetAnotherPacketParserParse.cs
@@ -141,18 +141,6 @@ namespace YetAnotherPacketParserAzureFunction
 
         private static IPacketConverterOptions GetOptions(HttpRequest request, ILogger log)
         {
-            if (TryGetStringValueFromQuery(request, "lineTolerance", out string stringValue) &&
-                int.TryParse(stringValue, out int maximumLineCountBeforeNextStage) &&
-                maximumLineCountBeforeNextStage > 0)
-            {
-                log.LogInformation($"Parsed tolerance: {maximumLineCountBeforeNextStage}");
-            }
-            else
-            {
-                maximumLineCountBeforeNextStage = 1;
-                log.LogInformation("Using the default tolerance");
-            }
-
             OutputFormat outputFormat;
             if (TryGetStringValueFromQuery(request, "format", out string outputFormatString))
             {
@@ -177,7 +165,7 @@ namespace YetAnotherPacketParserAzureFunction
                 log.LogInformation("Using the default format");
             }
 
-            if (TryGetStringValueFromQuery(request, "prettyPrint", out stringValue) &&
+            if (TryGetStringValueFromQuery(request, "prettyPrint", out string stringValue) &&
                 bool.TryParse(stringValue, out bool prettyPrint))
             {
                 log.LogInformation($"Parsed prettyPrint: {prettyPrint}");
@@ -195,7 +183,6 @@ namespace YetAnotherPacketParserAzureFunction
                     return new HtmlPacketCompilerOptions()
                     {
                         StreamName = "Request",
-                        MaximumLineCountBeforeNextStage = maximumLineCountBeforeNextStage,
                         MaximumPackets = MaximumPackets,
                         MaximumPacketSizeInBytes = MaximumPacketSizeInBytes,
                         Log = logMessage
@@ -206,7 +193,6 @@ namespace YetAnotherPacketParserAzureFunction
                     {
                         StreamName = "Request",
                         PrettyPrint = prettyPrint,
-                        MaximumLineCountBeforeNextStage = maximumLineCountBeforeNextStage,
                         MaximumPackets = MaximumPackets,
                         MaximumPacketSizeInBytes = MaximumPacketSizeInBytes,
                         Log = logMessage
@@ -218,7 +204,6 @@ namespace YetAnotherPacketParserAzureFunction
                     {
                         StreamName = "Request",
                         PrettyPrint = prettyPrint,
-                        MaximumLineCountBeforeNextStage = maximumLineCountBeforeNextStage,
                         MaximumPackets = MaximumPackets,
                         MaximumPacketSizeInBytes = MaximumPacketSizeInBytes,
                         Log = logMessage

--- a/YetAnotherPacketParser/YetAnotherPacketParserCommandLine/Options.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParserCommandLine/Options.cs
@@ -14,16 +14,6 @@ namespace YetAnotherPacketParserCommandLine
         [Option('o', "output", HelpText = "Path to the json output")]
         public string Output { get; set; }
 
-        [Option(
-            'l',
-            "lineTolerance",
-            HelpText = "Number of consecutive lines to look at to find the next part of the packet. A higher number " +
-                "means that parsing will not fail if a question has a new line in it, but it may skip over or " +
-                "combine questions. Note that answers must always be on one line. The default value is 1, which " +
-                "means that all questions must be on 1 line. This value must be greater than 0.",
-            Default = 2)]
-        public int MaximumLineCountBeforeNextStage { get; set; }
-
         [Option('p', "prettyPrint", HelpText = "Pretty prints the output by formatting it with whitespace. Defaults to true.", Default = true)]
         public bool PrettyPrint { get; set; }
 

--- a/YetAnotherPacketParser/YetAnotherPacketParserCommandLine/Program.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParserCommandLine/Program.cs
@@ -53,7 +53,6 @@ namespace YetAnotherPacketParserCommandLine
                     packetCompilerOptions = new JsonPacketCompilerOptions()
                     {
                         StreamName = options.Input,
-                        MaximumLineCountBeforeNextStage = options.MaximumLineCountBeforeNextStage,
                         PrettyPrint = options.PrettyPrint,
                         Log = log
                     };
@@ -62,7 +61,6 @@ namespace YetAnotherPacketParserCommandLine
                     packetCompilerOptions = new HtmlPacketCompilerOptions()
                     {
                         StreamName = options.Input,
-                        MaximumLineCountBeforeNextStage = options.MaximumLineCountBeforeNextStage,
                         Log = log
                     };
                     break;

--- a/YetAnotherPacketParser/YetAnotherPacketParserCommandLine/YetAnotherPacketParserCommandLine.csproj
+++ b/YetAnotherPacketParser/YetAnotherPacketParserCommandLine/YetAnotherPacketParserCommandLine.csproj
@@ -9,9 +9,9 @@
     <Copyright>(c) 2020 Alejandro Lopez-Lago</Copyright>
     <Description>Yet Another Packet Parser parses quiz bowl packets and translates them to different formats</Description>
     <Product>YAPP</Product>
-    <AssemblyVersion>0.1.1.0</AssemblyVersion>
-    <FileVersion>0.1.1.0</FileVersion>
-    <Version>0.1.1.0</Version>
+    <AssemblyVersion>0.2.0.0</AssemblyVersion>
+    <FileVersion>0.2.0.0</FileVersion>
+    <Version>0.2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Deprecate MaximumLineCountBeforeNextStage, and keep reading lines instead. Stop if we find the expected line type or something that isn't unclassified.
- Upgrade HtmlSanitizer to a secure version
-  Bump version to 0.2.0.0