### PR TITLE
Merged PR 221: v0.4.0 - Read post question metadata, support multiple…

### DIFF
--- a/YetAnotherPacketParser/YetAnotherPacketParser/Ast/BonusNode.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Ast/BonusNode.cs
@@ -5,20 +5,21 @@ namespace YetAnotherPacketParser.Ast
 {
     public class BonusNode
     {
-        public BonusNode(int number, FormattedText leadin, IEnumerable<BonusPartNode> parts, string? editorsNote)
+        public BonusNode(
+            int number, FormattedText leadin, IEnumerable<BonusPartNode> parts, string? metadata)
         {
-            this.EditorsNote = editorsNote;
             this.Leadin = leadin ?? throw new ArgumentNullException(nameof(leadin));
             this.Number = number;
             this.Parts = parts ?? throw new ArgumentNullException(nameof(parts));
+            this.Metadata = metadata;
         }
-
-        public string? EditorsNote { get; }
 
         public FormattedText Leadin { get; }
 
         public int Number { get; }
 
         public IEnumerable<BonusPartNode> Parts { get; }
+
+        public string? Metadata { get; }
     }
 }

--- a/YetAnotherPacketParser/YetAnotherPacketParser/Ast/TossupNode.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Ast/TossupNode.cs
@@ -4,17 +4,17 @@ namespace YetAnotherPacketParser.Ast
 {
     public class TossupNode
     {
-        public TossupNode(int number, QuestionNode question, string? editorsNote = null)
+        public TossupNode(int number, QuestionNode question, string? metadata = null)
         {
-            this.EditorsNote = editorsNote;
             this.Number = number;
             this.Question = question ?? throw new ArgumentNullException(nameof(question));
+            this.Metadata = metadata;
         }
-
-        public string? EditorsNote { get; }
 
         public int Number { get; }
 
         public QuestionNode Question { get; }
+
+        public string? Metadata { get; }
     }
 }

--- a/YetAnotherPacketParser/YetAnotherPacketParser/Compiler/Html/HtmlCompiler.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Compiler/Html/HtmlCompiler.cs
@@ -48,6 +48,12 @@ namespace YetAnotherPacketParser.Compiler.Html
             builder.Append(tossup.Number);
             builder.Append(". ");
             WriteQuestion(tossup.Question, builder);
+            if (!string.IsNullOrEmpty(tossup.Metadata))
+            {
+                builder.Append(tossup.Metadata);
+                builder.Append("<br>");
+            }
+
             builder.Append("</p>");
         }
 
@@ -62,6 +68,13 @@ namespace YetAnotherPacketParser.Compiler.Html
             {
                 WriteBonusPart(bonusPart, builder);
             }
+
+            if (!string.IsNullOrEmpty(bonus.Metadata))
+            {
+                builder.Append(bonus.Metadata);
+                builder.Append("<br>");
+            }
+
             builder.Append("</p>");
         }
 

--- a/YetAnotherPacketParser/YetAnotherPacketParser/Compiler/Json/JsonBonusNode.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Compiler/Json/JsonBonusNode.cs
@@ -24,6 +24,7 @@ namespace YetAnotherPacketParser.Compiler.Json
                 null;
             this.Values = new List<int>();
 
+            this.Metadata = bonusNode.Metadata;
             this.DifficultyModifiers = partNodes.Any(node => node.DifficultyModifier.HasValue) ? new List<char?>() : null;
 
             foreach (BonusPartNode partNode in partNodes)
@@ -41,6 +42,8 @@ namespace YetAnotherPacketParser.Compiler.Json
         public string Leadin { get; }
 
         public string? Leadin_sanitized { get; }
+
+        public string? Metadata { get; }
 
         public ICollection<string> Answers { get; }
 

--- a/YetAnotherPacketParser/YetAnotherPacketParser/Compiler/Json/JsonCompiler.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Compiler/Json/JsonCompiler.cs
@@ -25,7 +25,7 @@ namespace YetAnotherPacketParser.Compiler.Json
             // The format that Jerry's parser uses for JSON (and that the reader expects as a result) is different
             // than the structure of the PacketNode, so transform it to a structure close to it (minus author and
             // packet fields)
-            JsonPacketNode sanitizedJsonPacket = new JsonPacketNode(sanitizedPacket, !this.Options.ModaqFormat);
+            JsonPacketNode sanitizedJsonPacket = new JsonPacketNode(sanitizedPacket, this.Options.ModaqFormat);
 
             using (Stream stream = new MemoryStream())
             {

--- a/YetAnotherPacketParser/YetAnotherPacketParser/Compiler/Json/JsonPacketNode.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Compiler/Json/JsonPacketNode.cs
@@ -14,13 +14,13 @@ namespace YetAnotherPacketParser.Compiler.Json
             this.Tossups = new List<JsonTossupNode>();
         }
 
-        public JsonPacketNode(PacketNode node, bool includeSanitizedFields) : this()
+        public JsonPacketNode(PacketNode node, bool modaqFormat) : this()
         {
             Verify.IsNotNull(node, nameof(node));
 
             foreach (TossupNode tossupNode in node.Tossups)
             {
-                this.Tossups.Add(new JsonTossupNode(tossupNode, includeSanitizedFields));
+                this.Tossups.Add(new JsonTossupNode(tossupNode, modaqFormat));
             }
 
             if (node.Bonuses != null)
@@ -28,7 +28,7 @@ namespace YetAnotherPacketParser.Compiler.Json
                 this.Bonuses = new List<JsonBonusNode>();
                 foreach (BonusNode bonusNode in node.Bonuses)
                 {
-                    this.Bonuses.Add(new JsonBonusNode(bonusNode, includeSanitizedFields));
+                    this.Bonuses.Add(new JsonBonusNode(bonusNode, modaqFormat));
                 }
             }
         }

--- a/YetAnotherPacketParser/YetAnotherPacketParser/Compiler/Json/JsonTossupNode.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Compiler/Json/JsonTossupNode.cs
@@ -4,24 +4,31 @@ namespace YetAnotherPacketParser.Compiler.Json
 {
     internal class JsonTossupNode
     {
-        public JsonTossupNode(TossupNode node, bool includeSanitizedFields)
+        public JsonTossupNode(TossupNode node, bool modaqFormat)
         {
-            this.Number = node.Number;
+            if (!modaqFormat)
+            {
+                this.Number = node.Number;
+            }
+
             this.Question = JsonTextFormatter.ToStringWithTags(node.Question.Question);
-            this.Question_sanitized = includeSanitizedFields ?
-                JsonTextFormatter.ToStringWithoutTags(node.Question.Question) :
-                null;
+            this.Question_sanitized = modaqFormat ?
+                null :
+                JsonTextFormatter.ToStringWithoutTags(node.Question.Question);
             this.Answer = JsonTextFormatter.ToStringWithTags(node.Question.Answer);
-            this.Answer_sanitized = includeSanitizedFields ?
-                JsonTextFormatter.ToStringWithoutTags(node.Question.Answer) :
-                null;
+            this.Answer_sanitized = modaqFormat ?
+                null :
+                JsonTextFormatter.ToStringWithoutTags(node.Question.Answer);
+            this.Metadata = node.Metadata;
         }
 
-        public int Number { get; }
+        public int? Number { get; }
 
         public string Question { get; }
 
         public string Answer { get; }
+
+        public string? Metadata { get; }
 
         // We name it _sanitized so the Json property name converter uses the right casing
         public string? Question_sanitized { get; }

--- a/YetAnotherPacketParser/YetAnotherPacketParser/Compiler/SanitizeHtmlTransformer.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Compiler/SanitizeHtmlTransformer.cs
@@ -55,11 +55,12 @@ namespace YetAnotherPacketParser.Compiler
         private TossupNode SanitizeTossup(TossupNode node)
         {
             QuestionNode sanitizedQuestion = this.SanitizeQuestion(node.Question);
-            string? sanitizedEditorNotes = node.EditorsNote == null ?
+            // We want to escape rather just Sanitize
+            string? sanitizedMetadata = node.Metadata == null ?
                 null :
-                this.Sanitizer.Sanitize(node.EditorsNote);
+                this.Sanitizer.Sanitize(node.Metadata.Replace("<", "&lt;").Replace(">", "&gt;"));
 
-            return new TossupNode(node.Number, sanitizedQuestion, sanitizedEditorNotes);
+            return new TossupNode(node.Number, sanitizedQuestion, sanitizedMetadata);
         }
 
         private List<BonusNode> SanitizeBonuses(IEnumerable<BonusNode> bonuses)
@@ -81,11 +82,11 @@ namespace YetAnotherPacketParser.Compiler
             {
                 sanitizedBonusParts.Add(this.SanitizeBonusPart(bonusPart));
             }
-            string? sanitizedEditorNotes = node.EditorsNote != null ?
-                this.Sanitizer.Sanitize(node.EditorsNote) :
+            string? sanitizedMetadata = node.Metadata != null ?
+                this.Sanitizer.Sanitize(node.Metadata.Replace("<", "&lt;").Replace(">", "&gt;")) :
                 null;
 
-            return new BonusNode(node.Number, sanitizedLeadin, sanitizedBonusParts, sanitizedEditorNotes);
+            return new BonusNode(node.Number, sanitizedLeadin, sanitizedBonusParts, sanitizedMetadata);
         }
 
         private BonusPartNode SanitizeBonusPart(BonusPartNode node)

--- a/YetAnotherPacketParser/YetAnotherPacketParser/IResult.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/IResult.cs
@@ -9,7 +9,7 @@ namespace YetAnotherPacketParser
         // If Success is true, ErrorMessages should throw
         IEnumerable<string> ErrorMessages { get; }
 
-        // If Sucess if false, ErrorMessage should throw
+        // If Sucess if false, Value should throw
         T Value { get; }
     }
 }

--- a/YetAnotherPacketParser/YetAnotherPacketParser/Lexer/DocxLexer.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Lexer/DocxLexer.cs
@@ -251,6 +251,10 @@ namespace YetAnotherPacketParser.Lexer
                     {
                         line = new BonusPartLine(formattedText.Substring(matchValue.Length), partValue.Value, difficultyModifier);
                     }
+                    else if (LexerClassifier.TextStartsWithPostQuestionMetadata(unformattedText))
+                    {
+                        line = new PostQuestionMetadataLine(formattedText);
+                    }
                     else
                     {
                         line = new Line(formattedText);

--- a/YetAnotherPacketParser/YetAnotherPacketParser/Lexer/LexerClassifier.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Lexer/LexerClassifier.cs
@@ -13,6 +13,8 @@ namespace YetAnotherPacketParser.Lexer
             "^\\s*(\\d+|tb|tie(breaker)?)\\s*\\.\\s*", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex BonusPartValueRegex = new Regex(
             "^\\s*\\[\\s*(\\d)+\\s*[ehm]?\\s*\\]\\s*", RegexOptions.Compiled);
+        private static readonly Regex PostQuestionMetadataRegex = new Regex(
+            "^\\s*<(\\w|\\d|\\s|-|:|,)+(,(\\w|\\d|\\s|-|:|,)+)?>\\s*", RegexOptions.Compiled);
 
         public static bool TextStartsWithQuestionDigit(string text, out string matchValue, out int? number)
         {
@@ -82,6 +84,11 @@ namespace YetAnotherPacketParser.Lexer
 
             partValue = value;
             return true;
+        }
+
+        public static bool TextStartsWithPostQuestionMetadata(string text)
+        {
+            return PostQuestionMetadataRegex.Match(text).Success;
         }
     }
 }

--- a/YetAnotherPacketParser/YetAnotherPacketParser/Lexer/LineType.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Lexer/LineType.cs
@@ -5,6 +5,7 @@
         Unclassified,
         Answer,
         NumberedQuestion,
+        PostQuestionMetadata,
         BonusPart
     }
 }

--- a/YetAnotherPacketParser/YetAnotherPacketParser/Lexer/PostQuestionMetadataLine.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Lexer/PostQuestionMetadataLine.cs
@@ -1,0 +1,16 @@
+﻿namespace YetAnotherPacketParser.Lexer
+{
+    internal class PostQuestionMetadataLine : ILine
+    {
+        public PostQuestionMetadataLine(FormattedText text)
+        {
+            // TODO: Should we split it by ,? Should we take in two Formatted Texts, one for the first item, another for
+            // the second, or just take in an array of items?
+            this.Text = text;
+        }
+
+        public LineType Type => LineType.PostQuestionMetadata;
+
+        public FormattedText Text { get; }
+    }
+}

--- a/YetAnotherPacketParser/YetAnotherPacketParser/YetAnotherPacketParser.csproj
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/YetAnotherPacketParser.csproj
@@ -17,9 +17,9 @@
     <PackageTags>quizbowl packetparser quizbowlpacketparser</PackageTags>
     <PackageProjectUrl>https://github.com/alopezlago/YetAnotherPacketParser</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <AssemblyVersion>0.3.0.0</AssemblyVersion>
-    <FileVersion>0.3.0.0</FileVersion>
-    <Version>0.3.0.0</Version>
+    <AssemblyVersion>0.4.0.0</AssemblyVersion>
+    <FileVersion>0.4.0.0</FileVersion>
+    <Version>0.4.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/YetAnotherPacketParser/YetAnotherPacketParserAzureFunction/YetAnotherPacketParserAzureFunction.csproj
+++ b/YetAnotherPacketParser/YetAnotherPacketParserAzureFunction/YetAnotherPacketParserAzureFunction.csproj
@@ -7,9 +7,9 @@
     <AssemblyName>YetAnotherPacketParserAzureFunction</AssemblyName>
     <Authors>Alejandro Lopez-Lago</Authors>
     <Product>YAPP Azure Function</Product>
-    <AssemblyVersion>0.2.1.0</AssemblyVersion>
-    <FileVersion>0.2.1.0</FileVersion>
-    <Version>0.2.1.0</Version>
+    <AssemblyVersion>0.4.0.0</AssemblyVersion>
+    <FileVersion>0.4.0.0</FileVersion>
+    <Version>0.4.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.18.0" />

--- a/YetAnotherPacketParser/YetAnotherPacketParserCommandLine/Options.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParserCommandLine/Options.cs
@@ -32,5 +32,11 @@ namespace YetAnotherPacketParserCommandLine
 
         [Option('v', "verbose", HelpText = "Verbose logging", Required = false, Default = false)]
         public bool Verbose { get; set; }
+
+        [Option(
+            "mergeMultiple",
+            HelpText = "When parsing multiple packets from a zip file, return a JSON array or combined HTML file. If set to false, returns a zip file of individual packets. Defaults to false.",
+            Default = false)]
+        public bool MergeMultiplePackets { get; set; }
     }
 }

--- a/YetAnotherPacketParser/YetAnotherPacketParserCommandLine/YetAnotherPacketParserCommandLine.csproj
+++ b/YetAnotherPacketParser/YetAnotherPacketParserCommandLine/YetAnotherPacketParserCommandLine.csproj
@@ -9,9 +9,9 @@
     <Copyright>(c) 2020 Alejandro Lopez-Lago</Copyright>
     <Description>Yet Another Packet Parser parses quiz bowl packets and translates them to different formats</Description>
     <Product>YAPP</Product>
-    <AssemblyVersion>0.3.0.0</AssemblyVersion>
-    <FileVersion>0.3.0.0</FileVersion>
-    <Version>0.3.0.0</Version>
+    <AssemblyVersion>0.4.0.0</AssemblyVersion>
+    <FileVersion>0.4.0.0</FileVersion>
+    <Version>0.4.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/YetAnotherPacketParser/YetAnotherPacketParserTests/JsonCompilerTests.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParserTests/JsonCompilerTests.cs
@@ -20,7 +20,9 @@ namespace YetAnotherPacketParserTests
                 new TossupNode[]
                 {
                     new TossupNode(
-                        1, new QuestionNode(CreateFormattedText(questionText), CreateFormattedText(answerText)))
+                        1,
+                        new QuestionNode(CreateFormattedText(questionText), CreateFormattedText(answerText)),
+                        "<Alice - History>")
                 },
                 Array.Empty<BonusNode>());
 
@@ -34,7 +36,9 @@ namespace YetAnotherPacketParserTests
             Assert.IsFalse(string.IsNullOrEmpty(result), $"Compiled packet is empty. Packet: {result}");
             Assert.IsTrue(result.Contains(questionText), $"Couldn't find question text in packet. Packet: {result}");
             Assert.IsTrue(result.Contains(answerText), $"Couldn't find answer in packet. Packet: {result}");
-            Assert.IsTrue(result.Contains("_sanitized"), "There should be sanitized fields");
+            Assert.IsTrue(result.Contains("_sanitized"), "There should be sanitized fields. Packet: {result}");
+            Assert.IsTrue(result.Contains("number"), "There should be a number field. Packet: {result}");
+            Assert.IsTrue(result.Contains("metadata"), "There should be a metadata field. Packet: {result}");
 
             // TODO: Verify the results as a JsonPacketNode by either using Json.Net or creating a JsonConverter
         }
@@ -49,7 +53,9 @@ namespace YetAnotherPacketParserTests
                 new TossupNode[]
                 {
                     new TossupNode(
-                        1, new QuestionNode(CreateFormattedText(questionText), CreateFormattedText(answerText)))
+                        1,
+                        new QuestionNode(CreateFormattedText(questionText), CreateFormattedText(answerText)),
+                        "<Alice - History>")
                 },
                 Array.Empty<BonusNode>());
 
@@ -64,7 +70,9 @@ namespace YetAnotherPacketParserTests
             Assert.IsFalse(string.IsNullOrEmpty(result), $"Compiled packet is empty. Packet: {result}");
             Assert.IsTrue(result.Contains(questionText), $"Couldn't find question text in packet. Packet: {result}");
             Assert.IsTrue(result.Contains(answerText), $"Couldn't find answer in packet. Packet: {result}");
-            Assert.IsFalse(result.Contains("_sanitized"), "There should be no sanitized fields");
+            Assert.IsFalse(result.Contains("_sanitized"), "There should be no sanitized fields. Packet: {result}");
+            Assert.IsFalse(result.Contains("number"), "There should be no number field. Packet: {result}");
+            Assert.IsTrue(result.Contains("metadata"), "There should be a metadata field. Packet: {result}");
 
             // TODO: Verify the results as a JsonPacketNode by either using Json.Net or creating a JsonConverter
         }


### PR DESCRIPTION
… packets in one file

- Parse post-question metadata if it's there (#31)
    - This is often in the form of *<Author, Category>* or *<Category, Author>*
- Add option `mergeMultiple` to program and Azure Function to return multiple packets into a single JSON or HTML file
- Bump version to 0.4.0