### PR TITLE
Merged PR 286: v1.1.0 - Support [e]/[m]/[h] as bonus part indicators

### DIFF
--- a/YetAnotherPacketParser/.editorconfig
+++ b/YetAnotherPacketParser/.editorconfig
@@ -1,0 +1,229 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+file_header_template = unset
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = true
+dotnet_style_qualification_for_field = true
+dotnet_style_qualification_for_method = true
+dotnet_style_qualification_for_property = true
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_namespace_match_folder = true
+dotnet_style_null_propagation = true
+dotnet_style_object_initializer = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_compound_assignment = true
+dotnet_style_prefer_conditional_expression_over_assignment = true
+dotnet_style_prefer_conditional_expression_over_return = true
+dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
+
+# Field preferences
+dotnet_style_readonly_field = true
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental = true
+dotnet_style_allow_statement_immediately_after_block_experimental = true
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = false
+csharp_style_var_for_built_in_types = false
+csharp_style_var_when_type_is_apparent = false
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true
+csharp_style_expression_bodied_constructors = false
+csharp_style_expression_bodied_indexers = true
+csharp_style_expression_bodied_lambdas = true
+csharp_style_expression_bodied_local_functions = false
+csharp_style_expression_bodied_methods = false
+csharp_style_expression_bodied_operators = false
+csharp_style_expression_bodied_properties = true
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true
+csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_prefer_extended_property_pattern = true
+csharp_style_prefer_not_pattern = true
+csharp_style_prefer_pattern_matching = true
+csharp_style_prefer_switch_expression = true
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true
+
+# Modifier preferences
+csharp_prefer_static_local_function = true
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
+csharp_style_prefer_readonly_struct = true
+csharp_style_prefer_readonly_struct_member = true
+
+# Code-block preferences
+csharp_prefer_braces = true
+csharp_prefer_simple_using_statement = false:silent
+csharp_style_namespace_declarations = block_scoped
+csharp_style_prefer_method_group_conversion = true
+csharp_style_prefer_top_level_statements = true
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true
+csharp_style_deconstructed_variable_declaration = true
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+csharp_style_inlined_variable_declaration = true
+csharp_style_prefer_index_operator = true
+csharp_style_prefer_local_over_anonymous_function = true
+csharp_style_prefer_null_check_over_type_check = true
+csharp_style_prefer_range_operator = true
+csharp_style_prefer_tuple_swap = true
+csharp_style_prefer_utf8_string_literals = true
+csharp_style_throw_expression = true
+csharp_style_unused_value_assignment_preference = discard_variable
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace
+
+# New line preferences
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true
+csharp_style_allow_embedded_statements_on_same_line_experimental = true
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case

--- a/YetAnotherPacketParser/YetAnotherPacketParser/Compiler/Json/PascalCaseJsonNamingPolicy.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Compiler/Json/PascalCaseJsonNamingPolicy.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace YetAnotherPacketParser.Compiler.Json

--- a/YetAnotherPacketParser/YetAnotherPacketParser/Lexer/LexerClassifier.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Lexer/LexerClassifier.cs
@@ -5,6 +5,7 @@ namespace YetAnotherPacketParser.Lexer
 {
     internal static class LexerClassifier
     {
+        private const int DefaultBonusPartValue = 10;
         // Include spaces after the start tag so we get all of the spaces in a match, and we can avoid having to trim
         // them manually.
         private static readonly Regex AnswerRegEx = new Regex(
@@ -12,7 +13,7 @@ namespace YetAnotherPacketParser.Lexer
         private static readonly Regex QuestionDigitRegEx = new Regex(
             "^\\s*(\\d+|tb|tie(breaker)?)\\s*\\.\\s*", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex BonusPartValueRegex = new Regex(
-            "^\\s*\\[\\s*(\\d)+\\s*[ehm]?\\s*\\]\\s*", RegexOptions.Compiled);
+            "^\\s*\\[(\\s*(\\d)+\\s*[ehm]?\\s*|\\s*[ehm]\\s*)\\]\\s*", RegexOptions.Compiled);
         private static readonly Regex PostQuestionMetadataRegex = new Regex(
             "^\\s*<(\\w|\\d|\\s|-|:|,)+(,(\\w|\\d|\\s|-|:|,)+)?>\\s*", RegexOptions.Compiled);
 
@@ -68,7 +69,6 @@ namespace YetAnotherPacketParser.Lexer
                 .Replace("]", string.Empty, StringComparison.Ordinal)
                 .Trim();
 
-
             // If there's a difficulty modifier at the last character, include it. It's optional.
             char lastLetter = partValueText[^1];
             if (char.IsLetter(lastLetter))
@@ -77,12 +77,19 @@ namespace YetAnotherPacketParser.Lexer
                 partValueText = partValueText.Substring(0, partValueText.Length - 1);
             }
 
-            if (!int.TryParse(partValueText, out int value))
+            if (partValueText.Length == 0)
+            {
+                partValue = DefaultBonusPartValue;
+            }
+            else if (int.TryParse(partValueText, out int value))
+            {
+                partValue = value;
+            }
+            else
             {
                 return false;
             }
 
-            partValue = value;
             return true;
         }
 

--- a/YetAnotherPacketParser/YetAnotherPacketParser/README.md
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/README.md
@@ -1,0 +1,64 @@
+# Yet Another Packet Parser
+
+## Introduction
+
+Yet Another Packet Parser (YAPP) is a parser for quiz bowl packets written in C#. Some of its features are
+- Converts packets in a docx or HTML file to JSON or HTML
+- Can convert each packet in a zip file
+- Specific error messages that give a line number and text near where the parser failed
+- Configurable in how many lines to look ahead, which lets the parser successfully parse packets where some questions are split between multiple lines
+
+
+## Usage
+
+### Command-line program
+
+The command line program takes in a docx file and writes it to another file (by default, JSON)
+
+`YetAnotherPacketParserCommandLine.exe -i C:\qbsets\packet1.docx -o C:\qbsets\packet1.json`
+
+If you want to output it to an HTML file, set the format to html
+
+`YetAnotherPacketParserCommandLine.exe -i C:\qbsets\packet1.docx -o C:\qbsets\packet1.json -f html`
+
+To see the list of all flags, run
+
+`YetAnotherPacketParserCommandLine.exe --help`
+
+
+### Library
+
+YAPP comes with a C# library that is consumable through Nuget. You need to get the stream to the file and set the right compiler options, then call `PacketConverter.ConvertPackets`. For example, to convert a packet to HTML, you can use something like
+
+```
+IPacketConverterOptions packetCompilerOptions = new HtmlPacketCompilerOptions()
+{
+    StreamName = "packet1.html",
+    PrettyPrint = options.PrettyPrint
+};
+
+IEnumerable<ConvertResult> results;
+using (FileStream fileStream = new FileStream("C:\\qbsets\\packet1.docx", FileMode.Open, FileAccess.Read, FileShare.Read))
+{
+    results = await PacketConverter.ConvertPacketsAsync(fileStream, packetCompilerOptions);
+}
+
+ConvertResult compileResult = outputResults.First();
+if (!compileResult.Result.Success)
+{
+    Console.Error.WriteLine(compileResult.Result);
+    return;
+}
+
+File.WriteAllText(options.Output, compileResult.Result.Value);
+```
+
+Note that the method can take in a zip file too, and it will return all of the packets it attempted to parse.
+
+
+## Development
+
+### Requirements:
+- [.Net Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+  - If using Visual Studio, you need Visual Studio 2017.5
+  - Nuget packages should be automatically downloaded by running `dotnet build` or through `dotnet restore`

--- a/YetAnotherPacketParser/YetAnotherPacketParser/YetAnotherPacketParser.csproj
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/YetAnotherPacketParser.csproj
@@ -17,9 +17,9 @@
     <PackageTags>quizbowl packetparser quizbowlpacketparser</PackageTags>
     <PackageProjectUrl>https://github.com/alopezlago/YetAnotherPacketParser</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.0.1.0</FileVersion>
-    <Version>1.0.1.0</Version>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.1.0.0</Version>
 	<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	<AnalysisMode>Recommended</AnalysisMode>
 	<AnalysisModeSecurity>All</AnalysisModeSecurity>

--- a/YetAnotherPacketParser/YetAnotherPacketParserCommandLine/YetAnotherPacketParserCommandLine.csproj
+++ b/YetAnotherPacketParser/YetAnotherPacketParserCommandLine/YetAnotherPacketParserCommandLine.csproj
@@ -9,9 +9,9 @@
     <Copyright>(c) 2020 Alejandro Lopez-Lago</Copyright>
     <Description>Yet Another Packet Parser parses quiz bowl packets and translates them to different formats</Description>
     <Product>YAPP</Product>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.0.1.0</FileVersion>
-    <Version>1.0.1.0</Version>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.1.0.0</Version>
 	<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	<AnalysisMode>Recommended</AnalysisMode>
 	<AnalysisModeSecurity>All</AnalysisModeSecurity>

--- a/YetAnotherPacketParser/YetAnotherPacketParserTests/LexerClassifierTests.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParserTests/LexerClassifierTests.cs
@@ -6,6 +6,8 @@ namespace YetAnotherPacketParserTests
     [TestClass]
     public class LexerClassifierTests
     {
+        // TODO: Need test for [e]/[h]/[m] tags!
+
         [TestMethod]
         public void TextMatchesAnswer()
         {
@@ -102,6 +104,30 @@ namespace YetAnotherPacketParserTests
         public void TextMatchesBonusPartHardDifficultyModifier()
         {
             VerifyStartsWithBonusPart("[15h]", 15, 'h');
+        }
+
+        [TestMethod]
+        public void TextMatchesBonusPartOnlyEasyDifficultyModifier()
+        {
+            VerifyStartsWithBonusPart("[e]", 10, 'e');
+        }
+
+        [TestMethod]
+        public void TextMatchesBonusPartOnlyMediumDifficultyModifier()
+        {
+            VerifyStartsWithBonusPart("[m]", 10, 'm');
+        }
+
+        [TestMethod]
+        public void TextMatchesBonusPartOnlyHardDifficultyModifier()
+        {
+            VerifyStartsWithBonusPart("[h]", 10, 'h');
+        }
+
+        [TestMethod]
+        public void NonBonusPartNotMatchesOnlyUnknownDifficultyModifier()
+        {
+            VerifyDoesNotStartWithBonusPart("[u]");
         }
 
         [TestMethod]

--- a/YetAnotherPacketParser/YetAnotherPacketParserTests/YetAnotherPacketParserTests.csproj
+++ b/YetAnotherPacketParser/YetAnotherPacketParserTests/YetAnotherPacketParserTests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
     <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Support [e]/[m]/[h] as bonus part indicators (#41)
- Various minor code cleanup fixes
- Bump version to 1.1.0