### PR TITLE
v1.2.1 - Make post-question metadata parsing less strict

### DIFF
--- a/YetAnotherPacketParser/YetAnotherPacketParser/Lexer/LexerClassifier.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/Lexer/LexerClassifier.cs
@@ -15,7 +15,7 @@ namespace YetAnotherPacketParser.Lexer
         private static readonly Regex BonusPartValueRegex = new Regex(
             "^\\s*\\[(\\s*(\\d)+\\s*[ehm]?\\s*|\\s*[ehm]\\s*)\\]\\s*", RegexOptions.Compiled);
         private static readonly Regex PostQuestionMetadataRegex = new Regex(
-            "^\\s*<(\\w|\\d|\\s|-|:|,)+(,(\\w|\\d|\\s|-|:|,)+)?>\\s*", RegexOptions.Compiled);
+            "^\\s*<[^<>]+>\\s*", RegexOptions.Compiled);
 
         public static bool TextStartsWithQuestionDigit(string text, out string matchValue, out int? number)
         {

--- a/YetAnotherPacketParser/YetAnotherPacketParser/YetAnotherPacketParser.csproj
+++ b/YetAnotherPacketParser/YetAnotherPacketParser/YetAnotherPacketParser.csproj
@@ -17,9 +17,9 @@
     <PackageTags>quizbowl packetparser quizbowlpacketparser</PackageTags>
     <PackageProjectUrl>https://github.com/alopezlago/YetAnotherPacketParser</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
-    <Version>1.2.0.0</Version>
+    <AssemblyVersion>1.2.1.0</AssemblyVersion>
+    <FileVersion>1.2.1.0</FileVersion>
+    <Version>1.2.1.0</Version>
 	<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	<AnalysisMode>Recommended</AnalysisMode>
 	<AnalysisModeSecurity>All</AnalysisModeSecurity>
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.20.0" />
-    <PackageReference Include="HtmlSanitizer" Version="8.0.645" />
+    <PackageReference Include="HtmlSanitizer" Version="8.0.865" />
   </ItemGroup>
 
   <ItemGroup>

--- a/YetAnotherPacketParser/YetAnotherPacketParserAPI/Program.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParserAPI/Program.cs
@@ -6,7 +6,7 @@ using YetAnotherPacketParserAPI;
 
 // packets are about 80 KB, so 8 kb/s should finish it in 10 seconds
 MinDataRate minDataRate = new MinDataRate(8 * 1024, TimeSpan.FromSeconds(3));
-const int MaximumRequestInBytes = 2 * 1024 * 1024; // 2 MB
+const int MaximumRequestInBytes = 3 * 1024 * 1024; // 2 MB
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/YetAnotherPacketParser/YetAnotherPacketParserAPI/YetAnotherPacketParserAPI.csproj
+++ b/YetAnotherPacketParser/YetAnotherPacketParserAPI/YetAnotherPacketParserAPI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -11,7 +11,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/YetAnotherPacketParser/YetAnotherPacketParserCommandLine/YetAnotherPacketParserCommandLine.csproj
+++ b/YetAnotherPacketParser/YetAnotherPacketParserCommandLine/YetAnotherPacketParserCommandLine.csproj
@@ -9,9 +9,9 @@
     <Copyright>(c) 2020 Alejandro Lopez-Lago</Copyright>
     <Description>Yet Another Packet Parser parses quiz bowl packets and translates them to different formats</Description>
     <Product>YAPP</Product>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
-    <Version>1.2.0.0</Version>
+    <AssemblyVersion>1.2.1.0</AssemblyVersion>
+    <FileVersion>1.2.1.0</FileVersion>
+    <Version>1.2.1.0</Version>
 	<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	<AnalysisMode>Recommended</AnalysisMode>
 	<AnalysisModeSecurity>All</AnalysisModeSecurity>

--- a/YetAnotherPacketParser/YetAnotherPacketParserTests/HtmlLexerTests.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParserTests/HtmlLexerTests.cs
@@ -116,5 +116,113 @@ namespace YetAnotherPacketParserTests
                 classifiedLines[6].Text.UnformattedText.Trim(),
                 "Unexpected text for the seventh line");
         }
+
+        [TestMethod]
+        public async Task ParseHtml2()
+        {
+            const string htmlPacket = @"<html>
+    <body>
+        <p>
+            1. This is a tossup. <u>Underline</u> and <i>italics</i>. H<sub>2</sub>0 and x<sup>2</sup>.
+            <br>
+                ANSWER: <b>Tossup</b> Answer
+            </br>
+        </p>
+        <p></p>
+        <p>
+            1. This is a bonus.
+        <br>
+            [10] This is a two part bonus.
+        </br>
+        <br>
+            ANSWER: <b>Bonus</b> answer
+        </br>
+<br>
+{Some kind of note}
+</br>
+        <br>
+            [10] Second part.
+        </br>
+        <br>
+            ANSWER: Part answer
+        </br>
+        </p>
+    </body>
+</html>";
+
+            IResult<IEnumerable<ILine>> result = null;
+            using (Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(htmlPacket)))
+            {
+                ILexer lexer = new HtmlLexer();
+                result = await lexer.GetLines(stream);
+                Assert.IsTrue(result.Success, "Lexing failed");
+            }
+
+            IEnumerable<ILine> lines = result.Value;
+            Assert.IsNotNull(lines);
+
+            ILine[] classifiedLines = lines.Where(line => line.Type != LineType.Unclassified).ToArray();
+            LineType[] expectedTypes = new LineType[]
+            {
+                LineType.NumberedQuestion,
+                LineType.Answer,
+                LineType.NumberedQuestion,
+                LineType.BonusPart,
+                LineType.Answer,
+                LineType.BonusPart,
+                LineType.Answer
+            };
+            CollectionAssert.AreEqual(
+                expectedTypes,
+                classifiedLines.Select(line => line.Type).ToArray(),
+                "Unexpected types for a Line");
+
+            // TODO Need to verify formatted segments and texts
+            FormattedTextSegment[] expectedSegments = new FormattedTextSegment[]
+            {
+                new FormattedTextSegment("This is a tossup. "),
+                new FormattedTextSegment("Underline", underlined: true),
+                new FormattedTextSegment(" and "),
+                new FormattedTextSegment("italics", italic: true),
+                new FormattedTextSegment(". H"),
+                new FormattedTextSegment("2", isSubscript: true),
+                new FormattedTextSegment("0 and x"),
+                new FormattedTextSegment("2", isSuperscript: true),
+                new FormattedTextSegment(".\n            ")
+            };
+            CollectionAssert.AreEqual(
+                expectedSegments,
+                classifiedLines[0].Text.Segments.ToArray(),
+                "First line segments don't match");
+
+            expectedSegments = new FormattedTextSegment[]
+            {
+                new FormattedTextSegment("Tossup", bolded: true),
+                new FormattedTextSegment(" Answer\n            "),
+            };
+            CollectionAssert.AreEqual(
+                expectedSegments,
+                classifiedLines[1].Text.Segments.ToArray(),
+                "Second line segments don't match");
+
+            Assert.AreEqual(
+                "This is a bonus.", classifiedLines[2].Text.UnformattedText.Trim(), "Unexpected text for the third line");
+            Assert.AreEqual(
+                "This is a two part bonus.",
+                classifiedLines[3].Text.UnformattedText.Trim(),
+                "Unexpected text for the fourth line");
+            Assert.AreEqual(
+                "Bonus answer",
+                classifiedLines[4].Text.UnformattedText.Trim(),
+                "Unexpected text for the fifth line");
+            Assert.AreEqual(
+                "Second part.",
+                classifiedLines[5].Text.UnformattedText.Trim(),
+                "Unexpected text for the sixth line");
+            Assert.AreEqual(
+                "Part answer",
+                classifiedLines[6].Text.UnformattedText.Trim(),
+                "Unexpected text for the seventh line");
+        }
     }
 }

--- a/YetAnotherPacketParser/YetAnotherPacketParserTests/LexerClassifierTests.cs
+++ b/YetAnotherPacketParser/YetAnotherPacketParserTests/LexerClassifierTests.cs
@@ -6,8 +6,6 @@ namespace YetAnotherPacketParserTests
     [TestClass]
     public class LexerClassifierTests
     {
-        // TODO: Need test for [e]/[h]/[m] tags!
-
         [TestMethod]
         public void TextMatchesAnswer()
         {
@@ -164,6 +162,26 @@ namespace YetAnotherPacketParserTests
         public void NonBonusPartNotMatchesQuestionDigit()
         {
             VerifyDoesNotStartWithBonusPart("17.");
+        }
+
+        [TestMethod]
+        public void TextMatchesPostQuestionMetadata()
+        {
+            Assert.IsTrue(LexerClassifier.TextStartsWithPostQuestionMetadata("<Johnson, American Lit>"));
+        }
+
+        [TestMethod]
+        public void TextWithSpecialCharactersMatchesPostQuestionMetadata()
+        {
+            Assert.IsTrue(LexerClassifier.TextStartsWithPostQuestionMetadata("<Johnson, American Lit 1900+, 100%>"));
+            Assert.IsTrue(LexerClassifier.TextStartsWithPostQuestionMetadata("<Garcia-Garcia: American Lit ~2000>"));
+        }
+
+        [TestMethod]
+        public void TextDoesntMatchPostQuestionMetadata()
+        {
+            Assert.IsFalse(LexerClassifier.TextStartsWithPostQuestionMetadata("(Johnson, American Lit)"));
+            Assert.IsFalse(LexerClassifier.TextStartsWithPostQuestionMetadata("[Johnson, American Lit]"));
         }
 
         [TestMethod]

--- a/YetAnotherPacketParser/YetAnotherPacketParserTests/YetAnotherPacketParserTests.csproj
+++ b/YetAnotherPacketParser/YetAnotherPacketParserTests/YetAnotherPacketParserTests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
     <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- Make post-question metadata much less strict (#54)
- Increase max file size to 3 MB for the API
- Update some dependencies
- Bump version to 1.2.1